### PR TITLE
Remove unnecesary "header" block redeclaration

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Customer/layout/default.xml
+++ b/app/design/frontend/Magento/luma/Magento_Customer/layout/default.xml
@@ -15,11 +15,6 @@
                 </arguments>
             </block>
         </referenceBlock>
-        <block class="Magento\Theme\Block\Html\Header" name="header" as="header">
-            <arguments>
-                <argument name="show_part" xsi:type="string">welcome</argument>
-            </arguments>
-        </block>
         <move element="header" destination="header.links" before="-"/>
         <move element="register-link" destination="header.links"/>
         <move element="top.links" destination="customer"/>


### PR DESCRIPTION
### Description (*)
Removed because this block was already created in module Magento_Theme, so this redeclaration is just unnecesary

### Manual testing scenarios (*)
1. Create new module.
2. Create new default.xml and try to use referenceBlock to set the template.
3. Doesn't work, because Luma theme XML files are compiled after all modules and overrides the custom module modifications.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
