### PR TITLE
Backport [PR 18772] Remove unnecesary "header" block redeclaration

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Customer/layout/default.xml
+++ b/app/design/frontend/Magento/luma/Magento_Customer/layout/default.xml
@@ -15,11 +15,6 @@
                 </arguments>
             </block>
         </referenceBlock>
-        <block class="Magento\Theme\Block\Html\Header" name="header" as="header">
-            <arguments>
-                <argument name="show_part" xsi:type="string">welcome</argument>
-            </arguments>
-        </block>
         <move element="header" destination="header.links" before="-"/>
         <move element="register-link" destination="header.links"/>
         <move element="top.links" destination="customer"/>


### PR DESCRIPTION
Backport [PR 18772] Remove unnecesary header block redeclaration on Magento Luma Theme, which made impossible to set the header template through custom modules.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
